### PR TITLE
Ajout d'une vue par nombre

### DIFF
--- a/src/components/icicle/icicle-container.tsx
+++ b/src/components/icicle/icicle-container.tsx
@@ -30,6 +30,7 @@ export default function IcicleApiToProps({
         api.undo.commit();
       }}
       max_depth={database.maxDepth()}
+      width_by_size={icicle_state.widthBySize()}
       root_id={database.rootFfId()}
       sequence={icicle_state.sequence()}
       setDisplayRoot={icicle_state.setDisplayRoot}

--- a/src/components/icicle/icicle-main.js
+++ b/src/components/icicle/icicle-main.js
@@ -21,7 +21,9 @@ export default class IcicleMain extends PureComponent {
 
     this.ref = this.ref.bind(this);
 
-    this.fWidth = this.fWidth.bind(this);
+    this.getComputeWidthFunc = this.getComputeWidthFunc.bind(this);
+    this.computeWidthByNbFiles = this.computeWidthByNbFiles.bind(this);
+    this.computeWidthBySize = this.computeWidthBySize.bind(this);
     this.normalizeWidth = this.normalizeWidth.bind(this);
     this.trueFHeight = this.trueFHeight.bind(this);
 
@@ -94,10 +96,11 @@ export default class IcicleMain extends PureComponent {
 
   computeWidthRec(ids, x, dx) {
     const ans = [[x, dx]];
+
     if (ids.length < 2) {
       return ans;
     } else {
-      const fWidth = this.fWidth;
+      const fWidth = this.getComputeWidthFunc();
       const normalizeWidth = this.normalizeWidth;
       const getChildrenIdFromId = this.props.getChildrenIdFromId;
 
@@ -118,9 +121,18 @@ export default class IcicleMain extends PureComponent {
     }
   }
 
-  fWidth(id) {
-    const node = this.props.getFfByFfId(id);
-    return node.get("size");
+  getComputeWidthFunc() {
+    return this.props.width_by_size
+      ? this.computeWidthBySize
+      : this.computeWidthByNbFiles;
+  }
+
+  computeWidthBySize(id) {
+    return this.props.getFfByFfId(id).get("size");
+  }
+
+  computeWidthByNbFiles(id) {
+    return this.props.getFfByFfId(id).get("nb_files");
   }
 
   normalizeWidth(arr) {
@@ -205,6 +217,7 @@ export default class IcicleMain extends PureComponent {
     const minimap_y = icicle_height + 10;
     const minimap_width = breadcrumbs_width - 30;
     const minimap_height = ruler_height - 20;
+    const fWidth = this.getComputeWidthFunc();
 
     const icicle = (
       <g>
@@ -217,7 +230,7 @@ export default class IcicleMain extends PureComponent {
           tags={tags}
           root_id={this.props.root_id}
           display_root={this.props.display_root}
-          fWidth={this.fWidth}
+          fWidth={fWidth}
           normalizeWidth={this.normalizeWidth}
           trueFHeight={this.trueFHeight}
           getChildrenIdFromId={this.props.getChildrenIdFromId}
@@ -266,7 +279,7 @@ export default class IcicleMain extends PureComponent {
             dy={minimap_height - 10}
             root_id={this.props.root_id}
             display_root={ArrayUtil.empty}
-            fWidth={this.fWidth}
+            fWidth={fWidth}
             normalizeWidth={this.normalizeWidth}
             trueFHeight={this.trueFHeight}
             getChildrenIdFromId={this.props.getChildrenIdFromId}

--- a/src/components/navigation-bar.js
+++ b/src/components/navigation-bar.js
@@ -2,6 +2,7 @@ import React from "react";
 
 import BTRButton from "components/Buttons/back-to-root-button";
 import ToggleChangeSkin from "components/toggle-change-skin";
+import ToggleWidthBySize from "components/toggle-width-by-size";
 
 const grid_style = {
   background: "white",
@@ -17,16 +18,23 @@ const NavigationBar = props => {
 
   return (
     <div style={grid_style} className="grid-x align-middle">
-      <div className="cell small-4">
+      <div className="cell small-2">
         <BTRButton api={api} />
       </div>
-      <div className="cell small-8">
+      <div className="cell small-4">
         <div className="flex-container">
           <div className="flex-child-grow" />
           <div className="flex-child-auto">
             <ToggleChangeSkin api={api} />
           </div>
+        </div>
+      </div>
+      <div className="cell small-4">
+        <div className="flex-container">
           <div className="flex-child-grow" />
+          <div className="flex-child-auto">
+            <ToggleWidthBySize api={api} />
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/toggle-width-by-size.js
+++ b/src/components/toggle-width-by-size.js
@@ -1,0 +1,79 @@
+import React from "react";
+
+import { mkTB } from "components/Buttons/button";
+
+import TextAlignCenter from "components/text-align-center";
+import * as ObjectUtil from "util/object-util.ts";
+
+import * as Color from "util/color-util";
+import pick from "languages";
+
+const display_code = pick({
+  en: "Display:",
+  fr: "Affichage :"
+});
+
+const by_size = pick({
+  en: "By size",
+  fr: "Par volume"
+});
+
+const by_number = pick({
+  en: "By count",
+  fr: "Par nombre"
+});
+
+const Presentational = props => {
+  const button_style = {
+    margin: 0,
+    padding: "0.3em 10%",
+    fontSize: "1em",
+    fontWeight: "bold",
+    borderRadius: "0.4em"
+  };
+
+  return (
+    <div className="grid-x align-middle" style={{ minWidth: "25em" }}>
+      <div className="cell small-4">
+        <TextAlignCenter>{display_code}</TextAlignCenter>
+      </div>
+      <div className="cell small-4">
+        <TextAlignCenter>
+          {mkTB(
+            props.toggleChangeWidthBySize,
+            by_size,
+            !props.width_by_size,
+            Color.parentFolder(),
+            button_style
+          )}
+        </TextAlignCenter>
+      </div>
+      <div className="cell small-4">
+        <TextAlignCenter>
+          {mkTB(
+            props.toggleChangeWidthBySize,
+            by_number,
+            props.width_by_size,
+            Color.parentFolder(),
+            button_style
+          )}
+        </TextAlignCenter>
+      </div>
+    </div>
+  );
+};
+
+export default props => {
+  const api = props.api;
+  const icicle_state = api.icicle_state;
+
+  props = ObjectUtil.compose(
+    {
+      width_by_size: icicle_state.widthBySize(),
+      toggleChangeWidthBySize: icicle_state.toggleChangeWidthBySize
+    },
+    props
+  );
+
+  return <Presentational {...props} />;
+};

--- a/src/components/workspace.js
+++ b/src/components/workspace.js
@@ -111,7 +111,6 @@ class Workspace extends React.PureComponent {
     const api = this.props.api;
 
     const fillColor = this.fillColorFactory();
-
     return (
       <div className="grid-y grid-frame">
         <div className="cell">
@@ -155,7 +154,8 @@ export default props => {
       getFfByFfId: database.getFfByFfId,
       display_root: icicle_state.display_root(),
       root_id: database.rootFfId(),
-      change_skin: icicle_state.changeSkin()
+      change_skin: icicle_state.changeSkin(),
+      width_by_size: icicle_state.widthBySize()
     },
     props
   );

--- a/src/reducers/icicle-state.js
+++ b/src/reducers/icicle-state.js
@@ -7,7 +7,8 @@ const State = Record({
   dims: {},
   tag_id_to_highlight: "",
   display_root: [],
-  change_skin: false
+  change_skin: false,
+  width_by_size: true
 });
 
 const property_name = "icicle_state";
@@ -40,7 +41,8 @@ const reader = {
   isFocused: () => state => state.get("hover_seq").length > 0,
   isLocked,
   isZoomed: () => state => state.get("display_root").length > 0,
-  changeSkin: () => state => state.get("change_skin")
+  changeSkin: () => state => state.get("change_skin"),
+  widthBySize: () => state => state.get("width_by_size")
 };
 
 const setNoHover = () => state => state.update("hover_seq", () => []);
@@ -107,6 +109,14 @@ const toggleChangeSkin = () => state => {
   return state;
 };
 
+const toggleChangeWidthBySize = () => state => {
+  state = state.update("width_by_size", a => !a);
+  state = state.update("dims", () => {
+    return {};
+  });
+  return state;
+};
+
 const reInit = () => () => initialState();
 
 const writer = {
@@ -120,6 +130,7 @@ const writer = {
   setTagIdToHighlight,
   setNoTagIdToHighlight,
   toggleChangeSkin,
+  toggleChangeWidthBySize,
   reInit
 };
 


### PR DESCRIPTION
Il s'agit de permettre de passer d'une visualisation de l'arborescence
avec un affichage proportionnel à la taille à une autre proportionnelle
au nombre de fichiers.
Cela permet de voir les petits fichiers cachés au milieu de gros puisqu'ils
prennent la même place que les autres.

La proposition fonctionne (utilise l'atribut nb_files) mais je n'arrive pas
à rafraichir la vue lors de la bascule. Pour prendre en compte la nouvelle vue,
il faut double-cliquer sur un élément ;-(