### PR TITLE
fix(windows) : allow dialog box to quit the application, add a beta icon to METS button

### DIFF
--- a/electron/index.js
+++ b/electron/index.js
@@ -78,17 +78,18 @@ const askBeforeLeaving = () => {
       no = "no";
       yes = "yes";
     }
-    const option = {
+    const options = {
       type: "warning",
       buttons: [no, yes],
       defaultId: 0,
-      title,
-      message,
-      detail,
+      title: title,
+      message: message,
+      detail: detail,
       cancelId: 0
     };
-    dialog.showMessageBox(win, option, a => {
-      if (a === 1) {
+    let promiseResponse = dialog.showMessageBox(win, options);
+    promiseResponse.then(obj => {
+      if (obj.response === 1) {
         win.destroy();
       }
     });

--- a/src/components/Buttons/mets-button.js
+++ b/src/components/Buttons/mets-button.js
@@ -1,6 +1,6 @@
 import { mkB } from "components/Buttons/button";
 
-const label = "METS";
+const label = "METS \uD83E\uDD7C"; // \u{1F97C} labcoat or \u{1F9EA} test-tube
 
 const MetsButton = props => {
   const {


### PR DESCRIPTION
Sous Windows 10, l'application ne se fermait jamais. En passant par un Promise, on obtient le résultat attendu.

Proposition d'ajout d'un indicateur pour marquer que la fonction d'export METS n'est qu'une preuve de concept (beta version).