### PR TITLE
chore: disable jest cache in CI to limit resource use

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,7 +35,7 @@ Quality:
     - yarn --frozen-lockfile
   script:
     - yarn lint
-    - yarn test
+    - yarn test --no-cache
   cache:
     key: ${CI_JOB_NAME}
     paths:


### PR DESCRIPTION
Ca a l'air de corriger les problèmes de build. A suivre.